### PR TITLE
Added a short description of kontemplate

### DIFF
--- a/Operational_Excellence_deployment.md
+++ b/Operational_Excellence_deployment.md
@@ -11,6 +11,7 @@ Table of Contents
     * Infrastructure as Code
         * Azure Resource Manager templates
         * Terraform
+        * Lighter Helm alternative - kontemplate
     * Helm charts
     * [Choose the right VM size for your nodes](./Cost_Optimization.md#node---vm-sizes)
 
@@ -19,5 +20,9 @@ Table of Contents
 ## Azure Resource Manager templates
 
 ## Terraform
+
+## Lighter Helm alternative - kontemplate
+
+[Kontemplate](https://github.com/tazjin/kontemplate) is lighter and easier than Helm, which makes it a good alternative for projects that do not require a more complex solution. It is a simple CLI tool that can take sets of Kubernetes resource files with placeholders and insert values per environment. It works with standard Kubernetes YAML and/or JSON manifest files with templating instructions in a format based on Go's templating engine. It also has some interesting features like integration with kubectl (e.g. the --dry-run flag) and [pass](https://www.passwordstore.org), which makes it work well with CI pipelines.
 
 # Helm charts

--- a/Operational_Excellence_deployment.md
+++ b/Operational_Excellence_deployment.md
@@ -11,8 +11,8 @@ Table of Contents
     * Infrastructure as Code
         * Azure Resource Manager templates
         * Terraform
-        * Lighter Helm alternative - kontemplate
     * Helm charts
+    * Lighter Helm alternative - kontemplate
     * [Choose the right VM size for your nodes](./Cost_Optimization.md#node---vm-sizes)
 
 # Infrastructure as Code
@@ -21,12 +21,6 @@ Table of Contents
 
 ## Terraform
 
-## Lighter Helm alternative - kontemplate
-
-[Kontemplate](https://github.com/tazjin/kontemplate) is lighter and easier than Helm, which makes it a good alternative for projects that do not require a more complex solution. It is a simple CLI tool that can take sets of Kubernetes resource files with placeholders and insert values per environment. It works with standard Kubernetes YAML and/or JSON manifest files with templating instructions in a format based on Go's templating engine. It also has some interesting features like integration with kubectl (e.g. the --dry-run flag) and [pass](https://www.passwordstore.org), which makes it work well with CI pipelines.
-
-# Helm charts
-=======
 Terraform provides first-class support to define your resources in Azure in a
 declarative way. The configuration language is concise and very well adapted to
 pull-request-based work models where any infrastructure change is first
@@ -48,3 +42,7 @@ persons run Terraform, so that you have proper locking and accounting of the
 resources.
 
 # Helm charts
+
+# Lighter Helm alternative - kontemplate
+
+[Kontemplate](https://github.com/tazjin/kontemplate) is lighter and easier than Helm, which makes it a good alternative for projects that do not require a more complex solution. It is a simple CLI tool that can take sets of Kubernetes resource files with placeholders and insert values per environment. It works with standard Kubernetes YAML and/or JSON manifest files with templating instructions in a format based on Go's templating engine. It also has some interesting features like integration with kubectl (e.g. the --dry-run flag) and [pass](https://www.passwordstore.org), which makes it work well with CI pipelines.


### PR DESCRIPTION
I added a short description of kontemplate, a lighter alternative to Helm, to the docs regarding Infrastructure as Code.